### PR TITLE
Convert godaddy_dns_record into dictionary

### DIFF
--- a/tasks/add.record.yml
+++ b/tasks/add.record.yml
@@ -47,8 +47,7 @@
 
 - name: setup records_data_dict
   set_fact:
-    body_dict: []
-    #    - '{{godaddy_dns_record}}'
+    body_dict: [ '{{godaddy_dns_record}}' ]
 
 - name: setup setup record_data (json)
   set_fact:


### PR DESCRIPTION
When `body_dict` is not correctly set, the API request return 200, but the domain is not created.

This PR creates a dictionary from `godaddy_dns_record` that can be later converted to json